### PR TITLE
Fix: Start time to user Date.now()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,7 +254,7 @@ function logEvent(event, context, err, result, options, moesifController) {
   logData.response = {};
   logData.request.time = event && event.requestContext && event.requestContext.requestTimeEpoch ? 
     new Date(event && event.requestContext && event.requestContext.requestTimeEpoch) : 
-    startTime;
+    Date.now();
 
   logData.request.uri = getURLWithQueryStringParams(event);
   logData.request.verb = event.httpMethod;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moesif-aws-lambda",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "API Monitoring Middleware for AWS Lambda",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
Fix: Start time to user Date.now()
Bump version to 1.2.8